### PR TITLE
Allow passing marker options when calling startMarker

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ instance:
 
 |  method name   |  params | return |                      usage               |
 |----------------|---------|--------|---------------------------------|
-| startPolyline  | latlng\*  | created L.Polyline instance | Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user click. |
-| startPolygon  | latlng\*  | created L.Polygon instance | Start drawing a polygon. If latlng is given, a first point will be added. In any case, continuing on user click. |
-| startMarker  | latlng\*  | created L.Marker instance | Start adding a marker. If latlng is given, the marker will be shown first at this point. In any case, it will follow the user mouse, and will have a final latlng on next click (or touch). |
+| startPolyline  | latlng\*, options  | created L.Polyline instance | Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user click. If options is given, it will be passed to the polyline class constructor. |
+| startPolygon  | latlng\*, options  | created L.Polygon instance | Start drawing a polygon. If latlng is given, a first point will be added. In any case, continuing on user click. If options is given, it will be passed to the polygon class constructor. |
+| startMarker  | latlng\*, options  | created L.Marker instance | Start adding a marker. If latlng is given, the marker will be shown first at this point. In any case, it will follow the user mouse, and will have a final latlng on next click (or touch). If options is given, it will be passed to the marker class constructor.|
 | stopDrawing  | — | — | When you need to stop any ongoing drawing, without needing to know which editor is active. |
 
 #### Events

--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -137,8 +137,8 @@ L.Editable = L.Class.extend({
         return this.featuresLayer.addLayer(layer);
     },
 
-    startPolyline: function (latlng) {
-        var line = this.createPolyline([]);
+    startPolyline: function (latlng, options) {
+        var line = this.createPolyline([], options);
         this.connectCreatedToMap(line);
         var editor = line.enableEdit();
         editor.startDrawingForward();
@@ -146,8 +146,8 @@ L.Editable = L.Class.extend({
         return line;
     },
 
-    startPolygon: function (latlng) {
-        var polygon = this.createPolygon([]);
+    startPolygon: function (latlng, options) {
+        var polygon = this.createPolygon([], options);
         this.connectCreatedToMap(polygon);
         var editor = polygon.enableEdit();
         editor.startDrawingForward();
@@ -155,9 +155,9 @@ L.Editable = L.Class.extend({
         return polygon;
     },
 
-    startMarker: function (latlng, markerOptions) {
+    startMarker: function (latlng, options) {
         latlng = latlng || this.map.getCenter();
-        var marker = this.createMarker(latlng, markerOptions);
+        var marker = this.createMarker(latlng, options);
         this.connectCreatedToMap(marker);
         var editor = marker.enableEdit();
         editor.startDrawing();
@@ -177,20 +177,22 @@ L.Editable = L.Class.extend({
         return polygon;
     },
 
-    createPolyline: function (latlngs) {
-        var line = new this.options.polylineClass(latlngs, {editOptions: {editTools: this}});
+    createPolyline: function (latlngs, options) {
+        options = L.Util.extend({editOptions: {editTools: this}}, options);
+        var line = new this.options.polylineClass(latlngs, options);
         this.fireAndForward('editable:created', {layer: line});
         return line;
     },
 
-    createPolygon: function (latlngs) {
-        var polygon = new this.options.polygonClass(latlngs, {editOptions: {editTools: this}});
+    createPolygon: function (latlngs, options) {
+        options = L.Util.extend({editOptions: {editTools: this}}, options);
+        var polygon = new this.options.polygonClass(latlngs, options);
         this.fireAndForward('editable:created', {layer: polygon});
         return polygon;
     },
 
-    createMarker: function (latlng, markerOptions) {
-        var options = L.Util.extend({editOptions: {editTools: this}}, markerOptions);
+    createMarker: function (latlng, options) {
+        options = L.Util.extend({editOptions: {editTools: this}}, options);
         var marker = new this.options.markerClass(latlng, options);
         this.fireAndForward('editable:created', {layer: marker});
         return marker;

--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -155,9 +155,9 @@ L.Editable = L.Class.extend({
         return polygon;
     },
 
-    startMarker: function (latlng) {
+    startMarker: function (latlng, markerOptions) {
         latlng = latlng || this.map.getCenter();
-        var marker = this.createMarker(latlng);
+        var marker = this.createMarker(latlng, markerOptions);
         this.connectCreatedToMap(marker);
         var editor = marker.enableEdit();
         editor.startDrawing();
@@ -189,8 +189,9 @@ L.Editable = L.Class.extend({
         return polygon;
     },
 
-    createMarker: function (latlng) {
-        var marker = new this.options.markerClass(latlng, {editOptions: {editTools: this}});
+    createMarker: function (latlng, markerOptions) {
+        var options = L.Util.extend({editOptions: {editTools: this}}, markerOptions);
+        var marker = new this.options.markerClass(latlng, options);
         this.fireAndForward('editable:created', {layer: marker});
         return marker;
     }

--- a/test/MarkerEditor.js
+++ b/test/MarkerEditor.js
@@ -34,6 +34,7 @@ describe('L.MarkerEditor', function() {
             var title = 'My title';
             var other = this.map.editTools.startPolygon(null, {title:title});
             assert.equal(other.options.title, title);
+            this.map.removeLayer(other);
         });
     });
 

--- a/test/MarkerEditor.js
+++ b/test/MarkerEditor.js
@@ -29,7 +29,12 @@ describe('L.MarkerEditor', function() {
             happen.at('mousemove', 400, 400);
             assert.equal(before, marker._latlng);
         });
-
+		
+        it('should apply passed options to the marker', function(){
+            var title = 'My title';
+            var other = this.map.editTools.startPolygon(null, {title:title});
+            assert.equal(other.options.title, title);
+        });
     });
 
     describe('#disable()', function () {

--- a/test/PolygonEditor.js
+++ b/test/PolygonEditor.js
@@ -63,6 +63,11 @@ describe('L.PolygonEditor', function() {
             this.map.removeLayer(other);
         });
 
+        it('should apply passed options to the polygon', function(){
+            var className = 'my-class';
+            var other = this.map.editTools.startPolygon(null, {className:className});
+            assert.equal(other.options.className, className);
+        });
     });
 
     describe('#disable()', function () {

--- a/test/PolygonEditor.js
+++ b/test/PolygonEditor.js
@@ -67,6 +67,7 @@ describe('L.PolygonEditor', function() {
             var className = 'my-class';
             var other = this.map.editTools.startPolygon(null, {className:className});
             assert.equal(other.options.className, className);
+            this.map.removeLayer(other);
         });
     });
 

--- a/test/PolylineEditor.js
+++ b/test/PolylineEditor.js
@@ -47,6 +47,7 @@ describe('L.PolylineEditor', function() {
             var className = 'my-class';
             var other = this.map.editTools.startPolyline(null, {className:className});
             assert.equal(other.options.className, className);
+            this.map.removeLayer(other);
         });
     });
 

--- a/test/PolylineEditor.js
+++ b/test/PolylineEditor.js
@@ -42,7 +42,12 @@ describe('L.PolylineEditor', function() {
             happen.at('click', 300, 250);
             assert.equal(polyline._latlngs.length, 3);
         });
-
+		
+        it('should apply passed options to the polyline', function(){
+            var className = 'my-class';
+            var other = this.map.editTools.startPolyline(null, {className:className});
+            assert.equal(other.options.className, className);
+        });
     });
 
     describe('#disable()', function () {


### PR DESCRIPTION
For example, if you want a marker with a custom icon you can do this `map.editTools.startMarker(null, {icon: myIcon})`.